### PR TITLE
ページをリロードしたとき、編集中の内容を復帰できる

### DIFF
--- a/app/src/lib/components/Edit.svelte
+++ b/app/src/lib/components/Edit.svelte
@@ -8,7 +8,7 @@
   import Progress from './Progress.svelte';
   import Button, { Icon, Label } from '@smui/button';
   import elementResizeDetectorMaker from '@andybeersdev/element-resize-detector';
-  import { Routes } from '$lib/models/routes';
+  import { Routes, type RoutesJSON } from '$lib/models/routes';
   import type { Route } from '$lib/models/route';
   import type { Place } from '$lib/models/place';
 
@@ -148,6 +148,27 @@
     progressOpen = true;
     await routeElement.calc(active);
     progressOpen = false;
+  }
+
+  /**
+   * 出発日時別ルートを取得する
+   * @returns Routes クラスのオブジェクト
+   */
+  export function getRoutes() {
+    return routes;
+  }
+
+  /**
+   * 出発日時別ルートを設定する。
+   * ページリロード時など、セッションから復帰するときに呼び出される
+   * 復帰オブジェクトが空の場合は何もしない
+   * @param routes - 出発日時別ルートのJSON形式
+   */
+  export async function setRoutes(value: RoutesJSON) {
+    if (Object.keys(value).length === 0 && value.constructor === Object) return;
+    await routes.fromJSON(value);
+    tabs = routes.getDepartureDateTimes();
+    setTimeout(() => (active = tabs[0]));
   }
 </script>
 

--- a/app/src/lib/components/Place.svelte
+++ b/app/src/lib/components/Place.svelte
@@ -24,7 +24,11 @@
   let component: ComponentType<Constraint>;
   $: component = detectPlaceComponent(place, origin, destination);
 
-  function detectPlaceComponent(place: Place, origin: boolean, destination: boolean): ComponentType<Constraint> {
+  function detectPlaceComponent(
+    place: Place,
+    origin: boolean,
+    destination: boolean
+  ): ComponentType<Constraint> {
     if (isSpot(place)) {
       return place.waypoint && !origin && !destination ? SpotWaypoint : Spot;
     } else {

--- a/app/src/lib/models/place.ts
+++ b/app/src/lib/models/place.ts
@@ -33,7 +33,11 @@ export const isSpot = (place: Place) => {
  * @returns  フォーマット済み文字列
  */
 export function formatLocation(location?: Location) {
-  return (location ? `${location.latLng?.lat().toFixed(6)}, ${location.latLng?.lng().toFixed(6)}` : undefined) || '';
+  return (
+    (location
+      ? `${location.latLng?.lat().toFixed(6)}, ${location.latLng?.lng().toFixed(6)}`
+      : undefined) || ''
+  );
 }
 
 /**

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
+  import type { Snapshot } from './$types';
   import Edit from 'components/Edit.svelte';
+
+  /** ルート編集コンポーネント */
+  let edit: Edit;
+
+  /**
+   * ページのSnapshotをSessionStorageに保持する
+   */
+  export const snapshot: Snapshot<string> = {
+    capture: () => JSON.stringify(edit.getRoutes().toJSON()),
+    restore: (value) => edit.setRoutes(JSON.parse(value))
+  };
 </script>
 
 <article>
@@ -7,7 +19,7 @@
     <h3>Welcome to My Touring Links</h3>
   </header>
   <main>
-    <Edit />
+    <Edit bind:this={edit} />
   </main>
   <footer>@copy-right: ESM</footer>
 </article>


### PR DESCRIPTION
closed #26

SvelteKit の SnapShot 機能を使って SessionStorage に編集中のルート情報を保存して、ページ遷移やリロードしたときなどに復元できるようにする
