### PR TITLE
Firestore にルートのルールを設定した

### DIFF
--- a/app/src/lib/adapters/stored-gateway.test.ts
+++ b/app/src/lib/adapters/stored-gateway.test.ts
@@ -1,14 +1,18 @@
 import { type Firestore, setLogLevel } from 'firebase/firestore';
 import { afterAll, beforeAll, beforeEach, describe, it, expect, vi } from 'vitest';
 import { initializeTestEnvironment, type RulesTestEnvironment } from '@firebase/rules-unit-testing';
-import { converter, createStoredGateway } from './stored-gateway';
+import { createStoredGateway } from './stored-gateway';
 import { DEFAULT_STAYING_TIME, type Spot } from '$lib/models/place';
 import { faker } from '@faker-js/faker/locale/ja';
 import { Routes } from '$lib/models/routes';
 import { Settings } from 'luxon';
 import { readFileSync } from 'node:fs';
 import appRoot from 'app-root-path';
-import type { RoutesEntity } from '$lib/models/entity';
+import {
+  expectFirestorePermissionDenied,
+  expectFirestorePermissionUpdateSucceeds,
+  expectPermissionGetSucceeds
+} from '$lib/utils/test-helper';
 
 vi.mock('$lib/utils/googlemaps-util', () => ({
   TravelMode: { DRIVING: 'DRIVING' }
@@ -47,53 +51,267 @@ const fakeSpot = (args: Partial<Spot> = {}): Spot => {
   };
 };
 
-describe('StoredGateway<RoutesEntity>', () => {
-  it('save', async () => {
-    // arrange
-    const unauthedDb = testEnv.unauthenticatedContext().firestore();
-    const target = createStoredGateway(unauthedDb as unknown as Firestore, 'routes');
-    const now = new Date('2023-12-24T12:00+09:00');
-    Settings.now = () => now.getTime();
-    const routes = new Routes();
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
-    // action
-    const results = await target.save({
-      name: 'テストルート',
-      routes: routes.toJSON(),
-      userId: 'test-user'
+describe('FirestoreRoutesGateway', () => {
+  describe('save', () => {
+    it('認証されていない場合はエラーになる', async () => {
+      // arrange
+      const unauthedDb = testEnv.unauthenticatedContext().firestore();
+      const target = createStoredGateway(unauthedDb as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      // action & assert
+      await expectFirestorePermissionDenied(
+        target.save({
+          name: 'テストルート',
+          routes: routes.toJSON(),
+          userId: 'test-user'
+        })
+      );
     });
-    // assert
-    expect(results.id).not.toBeUndefined();
-    const actual = (await unauthedDb.collection('routes').doc(results.id).get()).data();
-    actual!.id = results.id;
-    actual!.createdAt = actual?.createdAt.toDate();
-    actual!.updatedAt = actual?.updatedAt.toDate();
-    expect(actual).toEqual(results);
+
+    it('他人では追加できない', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const target = createStoredGateway(alice as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      // action & assert
+      await expectFirestorePermissionDenied(
+        target.save({
+          name: 'テストルート',
+          routes: routes.toJSON(),
+          userId: 'bob'
+        })
+      );
+    });
+
+    it('認証されている場合は追加できる', async () => {
+      // arrange
+      const db = testEnv.authenticatedContext('alice').firestore();
+      const target = createStoredGateway(db as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      // action
+      const results = await expectFirestorePermissionUpdateSucceeds(
+        target.save({
+          name: 'テストルート',
+          routes: routes.toJSON(),
+          userId: 'alice'
+        })
+      );
+      // assert
+      expect(results.id).not.toBeUndefined();
+      const actual = (await db.collection('routes').doc(results.id).get()).data();
+      actual!.id = results.id;
+      actual!.createdAt = actual?.createdAt.toDate();
+      actual!.updatedAt = actual?.updatedAt.toDate();
+      expect(actual).toEqual(results);
+    });
+
+    it('他人のルートは更新できない', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const bob = testEnv.authenticatedContext('bob').firestore();
+      const target = createStoredGateway(alice as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        userId: 'bob',
+        createdAt: now,
+        updatedAt: now
+      };
+      const { id } = await bob.collection('routes').add(entity);
+      // action & assert
+      await expectFirestorePermissionDenied(
+        target.save({ ...entity, name: 'ルート変更', userId: 'alice', id })
+      );
+    });
+
+    it('自分のルートは更新できる', async () => {
+      // arrange
+      const db = testEnv.authenticatedContext('alice').firestore();
+      const target = createStoredGateway(db as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        userId: 'alice',
+        createdAt: now,
+        updatedAt: now
+      };
+      const { id } = await db.collection('routes').add(entity);
+      // action
+      const results = await expectFirestorePermissionUpdateSucceeds(
+        target.save({ ...entity, name: 'ルート変更', userId: 'alice', id })
+      );
+      // assert
+      const actual = (await db.collection('routes').doc(results.id).get()).data();
+      actual!.id = results.id;
+      actual!.createdAt = actual?.createdAt.toDate();
+      actual!.updatedAt = actual?.updatedAt.toDate();
+      expect(actual).toEqual(results);
+    });
   });
 
-  it('findById', async () => {
-    // arrange
-    const unauthedDb = testEnv.unauthenticatedContext().firestore();
-    const target = createStoredGateway(unauthedDb as unknown as Firestore, 'routes');
-    const now = new Date('2023-12-24T12:00+09:00');
-    Settings.now = () => now.getTime();
-    const routes = new Routes();
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
-    routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
-    const entity = {
-      name: 'テストルート',
-      routes: routes.toJSON(),
-      userId: 'test-user',
-      createdAt: now,
-      updatedAt: now
-    };
-    const saved = await unauthedDb.collection('routes').add(entity);
-    // action
-    const results = await target.findById(saved.id);
-    // assert
-    expect({ ...entity, id: saved.id }).toEqual(results);
+  describe('findById', () => {
+    it('認証していない場合は取得できない', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const unauthedDb = testEnv.unauthenticatedContext().firestore();
+      const target = createStoredGateway(unauthedDb as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        userId: 'alice',
+        createdAt: now,
+        updatedAt: now
+      };
+      const saved = await alice.collection('routes').add(entity);
+      // action & assert
+      await expectFirestorePermissionDenied(target.findById(saved.id));
+    });
+
+    it('他人のルートは取得できない', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const bob = testEnv.authenticatedContext('bob').firestore();
+      const target = createStoredGateway(alice as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        userId: 'bob',
+        createdAt: now,
+        updatedAt: now
+      };
+      const saved = await bob.collection('routes').add(entity);
+      // action & assert
+      await expectFirestorePermissionDenied(target.findById(saved.id));
+    });
+
+    it('自分のルートが取得できる', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const target = createStoredGateway(alice as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        userId: 'alice',
+        createdAt: now,
+        updatedAt: now
+      };
+      const saved = await alice.collection('routes').add(entity);
+      // action
+      const results = await expectPermissionGetSucceeds(target.findById(saved.id));
+      // assert
+      expect({ ...entity, id: saved.id }).toEqual(results);
+    });
+
+    it('公開指定されている場合はURLを知っている誰でもルートが取得できる', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const unauthedDb = testEnv.unauthenticatedContext().firestore();
+      const target = createStoredGateway(unauthedDb as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const routes = new Routes();
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'spot1' }));
+      routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+      const entity = {
+        name: 'テストルート',
+        routes: routes.toJSON(),
+        publish: true,
+        userId: 'alice',
+        createdAt: now,
+        updatedAt: now
+      };
+      const saved = await alice.collection('routes').add(entity);
+      // action
+      const results = await expectPermissionGetSucceeds(target.findById(saved.id));
+      // assert
+      expect({ ...entity, id: saved.id }).toEqual(results);
+    });
+  });
+
+  describe('findAllByUserId', () => {
+    it('自分のルートがすべて取得できる', async () => {
+      // arrange
+      const alice = testEnv.authenticatedContext('alice').firestore();
+      const bob = testEnv.authenticatedContext('bob').firestore();
+      const target = createStoredGateway(alice as unknown as Firestore, 'routes');
+      const now = new Date('2023-12-24T12:00+09:00');
+      Settings.now = () => now.getTime();
+      const all = [
+        { db: alice, user: 'alice', from: '2024-01-10T10:00+09:00' },
+        { db: bob, user: 'bob', from: '2024-01-10T10:00+09:00' },
+        { db: alice, user: 'alice', from: '2024-01-11T10:00+09:00' },
+        { db: bob, user: 'bob', from: '2024-01-11T10:00+09:00' },
+        { db: alice, user: 'alice', from: '2024-01-20T10:00+09:00' }
+      ];
+      all.forEach(async (data, index) => {
+        const routes = new Routes();
+        routes.changeDepartureDateTimeToRoutes(now, new Date(data.from));
+        routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'start' }));
+        routes.addPlaceByDepartureDateTimeToRoutes(now, fakeSpot({ placeId: 'goal' }));
+        const entity = {
+          name: `${data.user}のルート${index}`,
+          routes: routes.toJSON(),
+          userId: data.user,
+          createdAt: now,
+          updatedAt: now
+        };
+        await data.db.collection('routes').add(entity);
+      });
+      // action
+      const results = await expectPermissionGetSucceeds(target.findAllByUserId('alice'));
+      // assert
+      expect(results).toHaveLength(3);
+      expect(results.map((r) => r.name).sort()).toEqual([
+        'aliceのルート0',
+        'aliceのルート2',
+        'aliceのルート4'
+      ]);
+    });
   });
 });

--- a/app/src/lib/adapters/stored-gateway.ts
+++ b/app/src/lib/adapters/stored-gateway.ts
@@ -1,13 +1,22 @@
 import type { RoutesEntity, BaseEntity } from '$lib/models/entity';
 import type {
-  DocumentData,
   Firestore,
   FirestoreDataConverter,
   QueryDocumentSnapshot,
   SnapshotOptions,
   WithFieldValue
 } from 'firebase/firestore';
-import { Timestamp, addDoc, collection, doc, getDoc, setDoc } from 'firebase/firestore';
+import {
+  Timestamp,
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  setDoc,
+  where
+} from 'firebase/firestore';
 import { DateTime } from 'luxon';
 
 export type DATABASES = 'users' | 'routes';
@@ -17,10 +26,14 @@ export interface StoredGateway<T extends BaseEntity> {
   findById(id: string): Promise<T | undefined>;
 }
 
+export interface RoutesStoredGateway extends StoredGateway<RoutesEntity> {
+  findAllByUserId(userId: string): Promise<RoutesEntity[]>;
+}
+
 export const createStoredGateway = (db: Firestore, database: DATABASES) => {
   switch (database) {
     case 'routes':
-      return new FirestoreGateway<RoutesEntity>(db, database);
+      return new FirestoreRoutesGateway(db, database);
     default:
       throw Error(`unknown databse ${database}`);
   }
@@ -40,8 +53,8 @@ export const converter = <T extends BaseEntity>(): FirestoreDataConverter<T> => 
 
 class FirestoreGateway<T extends BaseEntity> implements StoredGateway<T> {
   constructor(
-    private db: Firestore,
-    private database: DATABASES
+    protected db: Firestore,
+    protected database: DATABASES
   ) {}
 
   async save(entity: T): Promise<T> {
@@ -64,5 +77,18 @@ class FirestoreGateway<T extends BaseEntity> implements StoredGateway<T> {
     const result = await getDoc(doc(this.db, this.database, id).withConverter(converter<T>()));
     if (!result.exists()) return undefined;
     return { ...result.data(), id };
+  }
+}
+
+class FirestoreRoutesGateway extends FirestoreGateway<RoutesEntity> implements RoutesStoredGateway {
+  async findAllByUserId(userId: string): Promise<RoutesEntity[]> {
+    const querySnapshot = await getDocs(
+      query(collection(this.db, this.database), where('userId', '==', userId)).withConverter(
+        converter<RoutesEntity>()
+      )
+    );
+    const routes: RoutesEntity[] = [];
+    querySnapshot.forEach((doc) => routes.push({ ...doc.data(), id: doc.id }));
+    return routes;
   }
 }

--- a/app/src/lib/models/entity.ts
+++ b/app/src/lib/models/entity.ts
@@ -20,6 +20,8 @@ export interface RoutesEntity extends BaseEntity {
   name: string;
   /** ルート情報 */
   routes: RoutesJSON;
+  /** 公開フラグ */
+  publish?: boolean;
   /** 作成者ID */
   userId: string;
 }

--- a/app/src/lib/utils/test-helper.ts
+++ b/app/src/lib/utils/test-helper.ts
@@ -1,0 +1,17 @@
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import { expect } from 'vitest';
+
+export async function expectFirestorePermissionDenied<T>(promise: Promise<T>) {
+  const errorResult = await assertFails(promise);
+  expect(errorResult.code).toBe('permission-denied' || 'PERMISSION_DENIED');
+}
+
+export async function expectFirestorePermissionUpdateSucceeds<T>(promise: Promise<T>) {
+  return await assertSucceeds(promise);
+}
+
+export async function expectPermissionGetSucceeds<T>(promise: Promise<T>) {
+  const result = await assertSucceeds(promise);
+  expect(result).not.toBeUndefined();
+  return result;
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,18 +2,10 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
-    match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2024, 1, 10);
+    match /routes/{routeId} {
+      allow read: if resource.data.userId == request.auth.uid || resource.data.publish == true;
+      allow create: if request.resource.data.userId == request.auth.uid;
+      allow update: if resource.data.userId == request.auth.uid && request.resource.data.userId == request.auth.uid;
     }
   }
 }


### PR DESCRIPTION
#28 

`@firebase/rules-unit-testing` によるテストはクイックスタートが参考になってやりやすい

https://github.com/firebase/quickstart-testing/tree/master/unit-test-security-rules