### PR TITLE
SSRレンダリングでブラウザAPIを呼び出してしまっていた

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,8 @@
   import { onMount } from 'svelte';
   import type { TouringEntity } from '$lib/models/entity';
 
+  /** このページはSSRしない */
+  export const ssr = false;
   /** セッションストア */
   const unsaved = persistBrowserSession(writable('UnsavedTouring'), 'unsaved-touring');
 


### PR DESCRIPTION
初期ページはブラウザ側のローカルストレージに前回の状態が残っているか判定してルーティングするだけなのでSSRしない設定にする。