### PR TITLE
ログインユーザーが保存したルートの一覧を表示できる

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 firebase.config.ts
+test-results

--- a/src/lib/components/Tabs.svelte
+++ b/src/lib/components/Tabs.svelte
@@ -57,7 +57,7 @@
           </Button>
         </Item>
         <Item>
-          <Button disabled={!loggedIn} on:click={saveTouring}>
+          <Button disabled={!loggedIn} on:click={() => saveTouring()}>
             <Icon class="material-icons">save</Icon>
             <ButtonLabel class="nowrap">保存</ButtonLabel>
           </Button>

--- a/src/lib/components/TouringLists.svelte
+++ b/src/lib/components/TouringLists.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import IconButton from '@smui/icon-button';
+  import DataTable, { Head, Body, Row, Cell } from '@smui/data-table';
+  import { DateTime } from 'luxon';
+  import Button, { Icon, Label } from '@smui/button';
+  import type { TouringEntity } from '$lib/models/entity';
+  import { goto } from '$app/navigation';
+
+  /** ツーリングの一覧 */
+  export let tourings: TouringEntity[];
+
+  /**
+   * 追加がクリックされたときのアクション
+   * `/tourings/new` へ遷移する
+   */
+  async function add() {
+    await goto(`/tourings/new`);
+  }
+
+  /**
+   * 編集がクリックされたときのアクション
+   * `/tourings/選択したID` へ遷移する
+   * @param id - 編集対象のツーリングID
+   */
+  async function change(id?: string) {
+    await goto(`/tourings/${id}`);
+  }
+
+  /**
+   * 削除がクリックされたときのアクション
+   * @param id - 削除対象のツーリングID
+   */
+  function remove(id?: string) {
+    // TODO
+  }
+</script>
+
+<div class="list">
+  <DataTable table$aria-label="ツーリング一覧" style="width: 100%;">
+    <Head>
+      <Row>
+        <Cell>出発日時</Cell>
+        <Cell>名前</Cell>
+        <Cell class="operation"></Cell>
+      </Row>
+    </Head>
+    <Body>
+      {#each tourings as touring, index}
+        <Row>
+          <Cell
+            >{DateTime.fromISO(Object.keys(touring.touring)[0])
+              .setZone('Asia/Tokyo')
+              .toFormat('yyyy/MM/dd（EEEEE）HH:mm', { locale: 'ja' })}</Cell
+          >
+          <Cell>{touring.name}</Cell>
+          <Cell class="operation">
+            <IconButton
+              class="material-icons"
+              on:click={() => change(touring.id)}
+              aria-label="編集"
+              size="mini">edit</IconButton
+            >
+            <IconButton
+              class="material-icons"
+              on:click={() => remove(touring.id)}
+              aria-label="削除"
+              size="mini">delete</IconButton
+            >
+          </Cell>
+        </Row>
+      {/each}
+    </Body>
+  </DataTable>
+</div>
+<div class="buttons">
+  <Button variant="unelevated" color="primary" class="button-shaped-round button" on:click={add}>
+    <Icon class="material-icons">add</Icon>
+    <Label>新しいツーリングを追加する</Label>
+  </Button>
+</div>
+
+<style>
+  .buttons {
+    padding: 1rem;
+  }
+  .buttons :global(.button) {
+    width: 100%;
+  }
+  .buttons :global(.button-shaped-round) {
+    border-radius: 36px;
+  }
+  .list :global(.operation) {
+    text-align: right;
+  }
+</style>

--- a/src/lib/server/models/touring.ts
+++ b/src/lib/server/models/touring.ts
@@ -26,7 +26,6 @@ export const store = async (user: User, entity: TouringEntity): Promise<TouringE
   } else {
     await update(user, entity);
   }
-  await db().doc(entity.id).set(toDatabaseEntity(user, entity));
   return entity;
 };
 
@@ -87,4 +86,15 @@ const toEntity = (
       updatedAt: findResult.updateTime?.toDate()
     }
   };
+};
+
+/**
+ * ユーザーに紐づくツーリングをすべて取得する
+ * @param user 取得するユーザー
+ * @returns ツーリング一覧
+ */
+export const findAllByUser = async (user: User): Promise<TouringEntity[]> => {
+  const results = await db().where('userId', '==', user.id).get();
+  if (results.empty) return [];
+  return results.docs.map((doc) => toEntity(doc).entity);
 };

--- a/src/lib/server/services/touring-service.ts
+++ b/src/lib/server/services/touring-service.ts
@@ -1,7 +1,11 @@
 import type { TouringEntity } from '$lib/models/entity';
 import type { User } from '@auth/sveltekit';
-import { store } from '$lib/server/models/touring';
+import { findAllByUser, store } from '$lib/server/models/touring';
 
 export const save = async (user: User, entity: TouringEntity): Promise<TouringEntity> => {
   return store(user, entity);
+};
+
+export const all = async (user: User): Promise<TouringEntity[]> => {
+  return findAllByUser(user);
 };

--- a/src/routes/api/tourings/+server.ts
+++ b/src/routes/api/tourings/+server.ts
@@ -1,5 +1,5 @@
 import { touringSchema } from '$lib/models/entity';
-import { save } from '$lib/server/services/touring-service';
+import { all, save } from '$lib/server/services/touring-service';
 import { error, json, type RequestHandler } from '@sveltejs/kit';
 import { status } from 'http-status';
 
@@ -17,4 +17,16 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
   const results = await save(user, requestBoby);
   return json({ id: results.id });
+};
+
+/**
+ * find all touring
+ */
+export const GET: RequestHandler = async ({ locals }) => {
+  const session = await locals.auth();
+  const user = session?.user;
+  if (!user) return error(status.UNAUTHORIZED);
+
+  const results = await all(user);
+  return json(results);
 };

--- a/src/routes/tourings/+page.server.ts
+++ b/src/routes/tourings/+page.server.ts
@@ -1,0 +1,14 @@
+import { getRequestEvent } from '$app/server';
+import { all } from '$lib/server/services/touring-service';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async () => {
+  const { locals } = getRequestEvent();
+  const session = await locals.auth();
+  const user = session?.user;
+  const loggedIn = !!user;
+  const tourings = loggedIn ? await all(user) : [];
+  return {
+    tourings
+  };
+};

--- a/src/routes/tourings/+page.svelte
+++ b/src/routes/tourings/+page.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { page } from '$app/stores';
+  import TouringLists from 'components/TouringLists.svelte';
+  import type { TouringEntity } from '$lib/models/entity';
+
+  let tourings: TouringEntity[] = [];
+
+  onMount(async () => {
+    tourings = $page.data.tourings;
+  });
+</script>
+
+<TouringLists {tourings} />


### PR DESCRIPTION
close #36 

- URL を `/tourings` にしたときに、保存済みの一覧が表示できること
- 一覧画面で追加ボタンが押されると、新しいツーリング作成画面へ遷移すること
- 編集ボタンが押されると、ID付きのURLへ遷移すること（ここは遷移するだけで動作はまだ実装されてない