### PR TITLE
ログインユーザーが保存したルートの編集ができる

### DIFF
--- a/src/lib/components/Edit.svelte
+++ b/src/lib/components/Edit.svelte
@@ -114,8 +114,27 @@
     if (!entity.id) {
       const placeholder = `${DateTime.fromJSDate(tabs[0]).setZone('Asia/Tokyo').toFormat('MM/dd', { locale: 'ja' })}出発ツーリング`;
       const name = prompt('保存するツーリングに名前をつけてください', placeholder);
+      if (name === null) {
+        console.log('canceled save touring');
+        return;
+      }
+      if (name === '') {
+        return saveTouring();
+      }
       entity.name = name || placeholder;
       fetch('/api/tourings', { method: 'POST', body: JSON.stringify(entity) });
+    } else {
+      const name = prompt('ツーリング名', entity.name);
+      if (name === null) {
+        console.log('canceled save touring');
+        return;
+      }
+      if (name === '') {
+        return saveTouring();
+      }
+      entity.name = name;
+      const { createdAt, updatedAt, ...updates } = entity;
+      fetch(`/api/tourings/${entity.id}`, { method: 'PUT', body: JSON.stringify(updates) });
     }
   }
 </script>

--- a/src/lib/components/TouringLists.svelte
+++ b/src/lib/components/TouringLists.svelte
@@ -5,6 +5,11 @@
   import Button, { Icon, Label } from '@smui/button';
   import type { TouringEntity } from '$lib/models/entity';
   import { goto } from '$app/navigation';
+  import { writable } from 'svelte/store';
+  import { persistBrowserSession } from '@macfja/svelte-persistent-store';
+
+  /** セッションストア */
+  let unsaved = persistBrowserSession(writable('UnsavedTouring'), 'unsaved-touring');
 
   /** ツーリングの一覧 */
   export let tourings: TouringEntity[];
@@ -14,6 +19,7 @@
    * `/tourings/new` へ遷移する
    */
   async function add() {
+    $unsaved = JSON.stringify({});
     await goto(`/tourings/new`);
   }
 
@@ -23,6 +29,7 @@
    * @param id - 編集対象のツーリングID
    */
   async function change(id?: string) {
+    $unsaved = JSON.stringify({});
     await goto(`/tourings/${id}`);
   }
 

--- a/src/lib/server/services/touring-service.ts
+++ b/src/lib/server/services/touring-service.ts
@@ -1,6 +1,6 @@
 import type { TouringEntity } from '$lib/models/entity';
 import type { User } from '@auth/sveltekit';
-import { findAllByUser, store } from '$lib/server/models/touring';
+import { findAllByUser, findById, store } from '$lib/server/models/touring';
 
 export const save = async (user: User, entity: TouringEntity): Promise<TouringEntity> => {
   return store(user, entity);
@@ -8,4 +8,8 @@ export const save = async (user: User, entity: TouringEntity): Promise<TouringEn
 
 export const all = async (user: User): Promise<TouringEntity[]> => {
   return findAllByUser(user);
+};
+
+export const get = async (user: User, id: string): Promise<TouringEntity | undefined> => {
+  return findById(user, id);
 };

--- a/src/routes/api/tourings/[id]/+server.ts
+++ b/src/routes/api/tourings/[id]/+server.ts
@@ -1,0 +1,20 @@
+import { touringSchema } from '$lib/models/entity';
+import { save } from '$lib/server/services/touring-service';
+import { error, json, type RequestHandler } from '@sveltejs/kit';
+import { status } from 'http-status';
+
+/**
+ * save existing touring
+ */
+export const PUT: RequestHandler = async ({ locals, request, params }) => {
+  const session = await locals.auth();
+  const user = session?.user;
+  if (!user) return error(status.UNAUTHORIZED);
+
+  const requestBoby = await request.json();
+  const validate = touringSchema.safeParse(requestBoby);
+  if (!validate.success || requestBoby.id !== params.id) return error(status.BAD_REQUEST);
+
+  const results = await save(user, requestBoby);
+  return json({ id: results.id });
+};

--- a/src/routes/api/tourings/[id]/server.test.ts
+++ b/src/routes/api/tourings/[id]/server.test.ts
@@ -1,19 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 import { faker } from '@faker-js/faker';
 import type { RequestEvent, HttpError } from '@sveltejs/kit';
-import { GET, POST } from './+server';
+import { PUT } from './+server';
 import { zocker } from 'zocker';
 import { userSchema } from '$lib/models/user';
 import { touringSchema } from '$lib/models/entity';
-import { DateTime } from 'luxon';
 import { placeSchema } from '$lib/models/place';
-import { all, save } from '$lib/server/services/touring-service';
-import removeUndefinedObjects from 'remove-undefined-objects';
+import { DateTime } from 'luxon';
+import { save } from '$lib/server/services/touring-service';
 
 vi.mock('$lib/server/services/touring-service');
 
-describe('POST', () => {
-  it('登録するユーザーが取得できないときは401エラーが戻ること', async () => {
+describe('PUT', () => {
+  it('更新するユーザーが取得できないときは401エラーが戻ること', async () => {
     // arrange
     const locals: App.Locals = {
       auth: vi.fn().mockResolvedValue(null),
@@ -21,15 +20,16 @@ describe('POST', () => {
       signIn: vi.fn(),
       signOut: vi.fn()
     };
+    const id = faker.string.uuid();
     const request = { json: vi.fn() } as unknown as Request;
     const expects: HttpError = {
       status: 401,
       body: { message: 'Error: 401' }
     };
     // action
-    expect(() => POST({ locals, request } as unknown as RequestEvent)).rejects.toThrowError(
-      expect.objectContaining(expects)
-    );
+    expect(() =>
+      PUT({ locals, request, params: { id } } as unknown as RequestEvent)
+    ).rejects.toThrowError(expect.objectContaining(expects));
   });
   it('バリデーションエラーがあるときは400エラーが戻ること', async () => {
     // arrange
@@ -41,15 +41,42 @@ describe('POST', () => {
       signOut: vi.fn()
     };
     const request = { json: vi.fn() } as unknown as Request;
-    vi.mocked(request.json).mockResolvedValue({ id: faker.string.uuid() });
+    const id = faker.string.uuid();
+    vi.mocked(request.json).mockResolvedValue({ id });
     const expects: HttpError = {
       status: 400,
       body: { message: 'Error: 400' }
     };
     // action
-    expect(() => POST({ locals, request } as unknown as RequestEvent)).rejects.toThrowError(
-      expect.objectContaining(expects)
-    );
+    expect(() =>
+      PUT({ locals, request, params: { id } } as unknown as RequestEvent)
+    ).rejects.toThrowError(expect.objectContaining(expects));
+  });
+  it('保存対象のツーリングIDとURLのIDが一致しないときは400エラーが戻ること', async () => {
+    // arrange
+    const user = zocker(userSchema).generate();
+    const locals: App.Locals = {
+      auth: vi.fn().mockResolvedValue({ user, expires: faker.date.future().toISOString() }),
+      getSession: vi.fn(),
+      signIn: vi.fn(),
+      signOut: vi.fn()
+    };
+    const touring = zocker(touringSchema)
+      .supply(touringSchema.shape.touring, () => ({
+        [DateTime.now().toJSDate().getTime()]: zocker(placeSchema).generateMany(2)
+      }))
+      .generate();
+    const request = { json: vi.fn() } as unknown as Request;
+    vi.mocked(request.json).mockResolvedValue(touring);
+    vi.mocked(save).mockRejectedValue(Error('呼ばれるはずのないモック'));
+    const expects: HttpError = {
+      status: 400,
+      body: { message: 'Error: 400' }
+    };
+    // action
+    expect(() =>
+      PUT({ locals, request, params: { id: faker.string.uuid() } } as unknown as RequestEvent)
+    ).rejects.toThrowError(expect.objectContaining(expects));
   });
   it('リクエストに問題ないときは保存を呼び出して保存したidを戻すこと', async () => {
     // arrange
@@ -67,53 +94,15 @@ describe('POST', () => {
       .generate();
     const request = { json: vi.fn() } as unknown as Request;
     vi.mocked(request.json).mockResolvedValue(touring);
-    const id = faker.string.uuid();
-    vi.mocked(save).mockResolvedValue({ ...touring, id });
+    vi.mocked(save).mockResolvedValue(touring);
     // action
-    const response = await POST({ locals, request } as unknown as RequestEvent);
+    const response = await PUT({
+      locals,
+      request,
+      params: { id: touring.id }
+    } as unknown as RequestEvent);
     // assertion
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ id });
-  });
-});
-
-describe('GET', () => {
-  it('取得するユーザーが取得できないときは401エラーが戻ること', async () => {
-    // arrange
-    const locals: App.Locals = {
-      auth: vi.fn().mockResolvedValue(null),
-      getSession: vi.fn(),
-      signIn: vi.fn(),
-      signOut: vi.fn()
-    };
-    const expects: HttpError = {
-      status: 401,
-      body: { message: 'Error: 401' }
-    };
-    // action
-    expect(() => GET({ locals } as unknown as RequestEvent)).rejects.toThrowError(
-      expect.objectContaining(expects)
-    );
-  });
-  it('登録ユーザーの場合は登録されているツーリングの一覧を戻すこと', async () => {
-    // arrange
-    const user = zocker(userSchema).generate();
-    const tourings = zocker(touringSchema)
-      .supply(touringSchema.shape.touring, () => ({
-        [DateTime.now().toJSDate().getTime()]: zocker(placeSchema).generateMany(2)
-      }))
-      .generateMany(4);
-    const locals: App.Locals = {
-      auth: vi.fn().mockResolvedValue({ user, expires: faker.date.future().toISOString() }),
-      getSession: vi.fn(),
-      signIn: vi.fn(),
-      signOut: vi.fn()
-    };
-    vi.mocked(all).mockResolvedValue(tourings);
-    // action
-    const response = await GET({ locals } as unknown as RequestEvent);
-    // assertion
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual(tourings.map((t) => removeUndefinedObjects(t)));
+    await expect(response.json()).resolves.toEqual({ id: touring.id });
   });
 });

--- a/src/routes/tourings/[id]/+page.server.ts
+++ b/src/routes/tourings/[id]/+page.server.ts
@@ -1,0 +1,24 @@
+import { getRequestEvent } from '$app/server';
+import type { PageServerLoad } from './$types';
+import { status } from 'http-status';
+import { error } from '@sveltejs/kit';
+import { get } from '$lib/server/services/touring-service';
+
+export const load: PageServerLoad = async ({ params }) => {
+  if (params.id === 'new') return;
+
+  const { locals } = getRequestEvent();
+  const session = await locals.auth();
+  const user = session?.user;
+  const loggedIn = !!user;
+  if (!loggedIn) {
+    error(status.UNAUTHORIZED, { message: 'Unauthorized' });
+  }
+  const touring = await get(user, params.id);
+  if (touring === undefined) {
+    error(status.NOT_FOUND, { message: 'Not found' });
+  }
+  return {
+    touring
+  };
+};

--- a/src/routes/tourings/[id]/+page.svelte
+++ b/src/routes/tourings/[id]/+page.svelte
@@ -5,6 +5,7 @@
   import { beforeNavigate } from '$app/navigation';
   import { onMount } from 'svelte';
   import { backButton } from '$lib/store/back-button';
+  import { page } from '$app/stores';
 
   /** セッションストア */
   let unsaved = persistBrowserSession(writable('UnsavedTouring'), 'unsaved-touring');
@@ -17,7 +18,16 @@
 
   onMount(async () => {
     try {
-      edit.setTouring(JSON.parse($unsaved));
+      const session = JSON.parse($unsaved);
+      if ($page.data.touring === undefined) {
+        edit.setTouring(session);
+      } else {
+        if (Object.keys(session).length === 0) {
+          edit.setTouring($page.data.touring);
+        } else {
+          edit.setTouring(session);
+        }
+      }
     } catch (e) {
       // ignore error
     }


### PR DESCRIPTION
close #37 

- 保存ボタンを押したときに、既存ルートの編集だったら更新APIを呼び出すようにした
- ツーリング一覧から既存のルートを選択したときは、セッションストアの値を空にする。これは、ページがSSRでレンダリングされたとき、セッションストアにないときDBからセッションストアにコピーするかどうか判定するため。もしセッションストアに保持済みである場合は、設定画面などへ遷移したときの編集中の値であるため、DBの値で上書きしないようにする。
- 編集画面をレンダリングするときにURLのIDのツーリングをDBから取得する
- 更新APIを追加