### PR TITLE
ログインユーザーが保存したルートを削除できる

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -27,7 +27,25 @@ module.exports = {
     'import/no-absolute-path': [2, { commonjs: false, amd: true }],
     'import/no-relative-parent-imports': 'error',
     'no-console': 'error',
-    'object-shorthand': ['error', 'always']
+    'object-shorthand': ['error', 'always'],
+    'no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_'
+      }
+    ],
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_'
+      }
+    ]
   },
   overrides: [
     {

--- a/src/lib/components/Edit.svelte
+++ b/src/lib/components/Edit.svelte
@@ -11,6 +11,7 @@
   import type { Route } from '$lib/models/route';
   import type { Place } from '$lib/models/place';
   import { DateTime } from 'luxon';
+  import status from 'http-status';
 
   /** Map コンポーネント */
   let map: Map;
@@ -115,26 +116,32 @@
       const placeholder = `${DateTime.fromJSDate(tabs[0]).setZone('Asia/Tokyo').toFormat('MM/dd', { locale: 'ja' })}出発ツーリング`;
       const name = prompt('保存するツーリングに名前をつけてください', placeholder);
       if (name === null) {
-        console.log('canceled save touring');
         return;
       }
       if (name === '') {
         return saveTouring();
       }
       entity.name = name || placeholder;
-      fetch('/api/tourings', { method: 'POST', body: JSON.stringify(entity) });
+      const response = await fetch('/api/tourings', {
+        method: 'POST',
+        body: JSON.stringify(entity)
+      });
+      if (response.status !== status.OK) alert('保存に失敗しました');
     } else {
       const name = prompt('ツーリング名', entity.name);
       if (name === null) {
-        console.log('canceled save touring');
         return;
       }
       if (name === '') {
         return saveTouring();
       }
       entity.name = name;
-      const { createdAt, updatedAt, ...updates } = entity;
-      fetch(`/api/tourings/${entity.id}`, { method: 'PUT', body: JSON.stringify(updates) });
+      const { createdAt: _createdAt, updatedAt: _updatedAt, ...updates } = entity;
+      const response = await fetch(`/api/tourings/${entity.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(updates)
+      });
+      if (response.status !== status.OK) alert('保存に失敗しました');
     }
   }
 </script>

--- a/src/lib/components/TouringLists.svelte
+++ b/src/lib/components/TouringLists.svelte
@@ -7,6 +7,7 @@
   import { goto } from '$app/navigation';
   import { writable } from 'svelte/store';
   import { persistBrowserSession } from '@macfja/svelte-persistent-store';
+  import status from 'http-status';
 
   /** セッションストア */
   let unsaved = persistBrowserSession(writable('UnsavedTouring'), 'unsaved-touring');
@@ -36,9 +37,14 @@
   /**
    * 削除がクリックされたときのアクション
    * @param id - 削除対象のツーリングID
+   * @param name - 削除対象のツーリング名
    */
-  function remove(id?: string) {
-    // TODO
+  async function remove(id: string | undefined, name: string) {
+    if (id === undefined) return;
+    if (confirm(`${name}を削除しても良いですか？`) === false) return;
+    const response = await fetch(`/api/tourings/${id}`, { method: 'DELETE' });
+    if (response.status !== status.OK) return alert('削除に失敗しました');
+    tourings = tourings.filter((touring) => touring.id !== id);
   }
 </script>
 
@@ -52,7 +58,7 @@
       </Row>
     </Head>
     <Body>
-      {#each tourings as touring, index}
+      {#each tourings as touring}
         <Row>
           <Cell
             >{DateTime.fromISO(Object.keys(touring.touring)[0])
@@ -69,7 +75,7 @@
             >
             <IconButton
               class="material-icons"
-              on:click={() => remove(touring.id)}
+              on:click={() => remove(touring.id, touring.name)}
               aria-label="削除"
               size="mini">delete</IconButton
             >

--- a/src/lib/components/TouringSettings.svelte
+++ b/src/lib/components/TouringSettings.svelte
@@ -9,7 +9,7 @@
   /** DateTimePicker タグ */
   let dateTimePicker: DateTimePicker;
   /** 新規タブ追加中の場合はコールバックが設定される */
-  let addTabCallback: ((date: Date) => void) | undefined;
+  let addTabCallback: ((_date: Date) => void) | undefined;
   /** 出発日時別ルート */
   let touring = new Touring();
   /** 編集中のエンティティ */

--- a/src/lib/server/models/touring.ts
+++ b/src/lib/server/models/touring.ts
@@ -31,7 +31,7 @@ export const store = async (user: User, entity: TouringEntity): Promise<TouringE
 
 const toDatabaseEntity = (user: User, entity: TouringEntity): TouringDatabaseEntity => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, createdAt, updatedAt, ...toDatabase } = entity;
+  const { id: _id, createdAt: _createdAt, updatedAt: _updatedAt, ...toDatabase } = entity;
   return {
     ...toDatabase,
     userId: user.id!
@@ -97,4 +97,17 @@ export const findAllByUser = async (user: User): Promise<TouringEntity[]> => {
   const results = await db().where('userId', '==', user.id).get();
   if (results.empty) return [];
   return results.docs.map((doc) => toEntity(doc).entity);
+};
+
+/**
+ * データーベースから削除する
+ * @param user 削除するユーザー
+ * @param touringId 削除対象のツーリングID
+ */
+export const remove = async (user: User, touringId: string) => {
+  const doc = db().doc(touringId);
+  const current = await doc.get();
+  const data = current && current.data();
+  if (data?.userId !== user.id) throw Error('Not found remove data');
+  await doc.delete();
 };

--- a/src/lib/server/services/touring-service.ts
+++ b/src/lib/server/services/touring-service.ts
@@ -1,6 +1,6 @@
 import type { TouringEntity } from '$lib/models/entity';
 import type { User } from '@auth/sveltekit';
-import { findAllByUser, findById, store } from '$lib/server/models/touring';
+import { findAllByUser, findById, remove, store } from '$lib/server/models/touring';
 
 export const save = async (user: User, entity: TouringEntity): Promise<TouringEntity> => {
   return store(user, entity);
@@ -12,4 +12,8 @@ export const all = async (user: User): Promise<TouringEntity[]> => {
 
 export const get = async (user: User, id: string): Promise<TouringEntity | undefined> => {
   return findById(user, id);
+};
+
+export const del = async (user: User, id: string): Promise<void> => {
+  return remove(user, id);
 };

--- a/src/routes/api/tourings/[id]/+server.ts
+++ b/src/routes/api/tourings/[id]/+server.ts
@@ -1,5 +1,5 @@
 import { touringSchema } from '$lib/models/entity';
-import { save } from '$lib/server/services/touring-service';
+import { save, del } from '$lib/server/services/touring-service';
 import { error, json, type RequestHandler } from '@sveltejs/kit';
 import { status } from 'http-status';
 
@@ -17,4 +17,17 @@ export const PUT: RequestHandler = async ({ locals, request, params }) => {
 
   const results = await save(user, requestBoby);
   return json({ id: results.id });
+};
+
+/**
+ * remove existing touring
+ */
+export const DELETE: RequestHandler = async ({ locals, params }) => {
+  const session = await locals.auth();
+  const user = session?.user;
+  if (!user) return error(status.UNAUTHORIZED);
+  if (params.id === undefined) return error(status.BAD_REQUEST);
+
+  await del(user, params.id);
+  return json({ id: params.id });
 };


### PR DESCRIPTION
close #38 

### 削除対応

- DELETE api を追加
- 削除サービス del を追加
- データベースから削除する remove 関数を追加
- ツーリング一覧から削除ボタンが押されたときに、確認ダイアログを出して、okされたときに削除 API を呼び出すようにした

### その他

未使用の変数で Lint エラーになっていたけど、不要な変数を Separated で取り除きたいときとかあるので、アンダースコア始まりの変数宣言は未使用にしないルールを追加した
